### PR TITLE
chore: update carbon-addons-boomerang-react to 1.2.3

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,7 +13,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "@boomerang-io/carbon-addons-boomerang-react": "1.1.7",
+    "@boomerang-io/carbon-addons-boomerang-react": "1.2.3",
     "@boomerang-io/gatsby-theme-boomerang": "0.1.0-beta.18",
     "gatsby": "^3.6.1",
     "react": "^16.13.1",

--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -5,7 +5,7 @@
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",
   "dependencies": {
-    "@boomerang-io/carbon-addons-boomerang-react": "1.1.7",
+    "@boomerang-io/carbon-addons-boomerang-react": "1.2.3",
     "@carbon/icons-react": "10.22.0",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "3.0.2",
     "app-root-path": "2.2.1",

--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "0.2.0-beta.22",
+  "version": "0.2.0-beta.23",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.22",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "0.2.0-beta.23",
+  "version": "0.2.0-beta.24",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,6 +1039,89 @@
     warning "^4.0.3"
     window-or-global "^1.0.1"
 
+"@boomerang-io/carbon-addons-boomerang-react@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@boomerang-io/carbon-addons-boomerang-react/-/carbon-addons-boomerang-react-1.2.3.tgz#d54633fcf7691b2cc48a59a01994173ab52d960c"
+  integrity sha512-2LF8M2zm8IGkDMwwlMcIoqAIhvWFCsQFU7FCv0KHkEZ8onEbqLwyZqG32F/76KNnruDhfhQBKIJ2ozyO46YADA==
+  dependencies:
+    "@carbon/elements" "^10.21.0"
+    "@carbon/themes" "^10.21.0"
+    "@stomp/stompjs" "^5.4.2"
+    "@tippyjs/react" "^4.0.2"
+    carbon-icons "^7.0.7"
+    classnames "^2.2.5"
+    date-fns "^1.30.1"
+    dompurify "^2.0.6"
+    downshift "^5.2.1"
+    invariant "^2.2.3"
+    js-file-download "^0.4.7"
+    lodash.isequal "^4.5.0"
+    match-sorter "^4.2.1"
+    react-autosuggest "^9.4.3"
+    react-dropzone "^10.0.6"
+    react-focus-trap "^2.7.1"
+    react-modal "^3.10.1"
+    react-toastify "^5.3.2"
+    warning "^4.0.3"
+    window-or-global "^1.0.1"
+
+"@boomerang-io/gatsby-theme-boomerang@0.1.0-beta.18":
+  version "0.1.0-beta.18"
+  resolved "https://registry.yarnpkg.com/@boomerang-io/gatsby-theme-boomerang/-/gatsby-theme-boomerang-0.1.0-beta.18.tgz#173653ec32ce59fb97c10f631305156b2e6fa487"
+  integrity sha512-bx6csKtJWmhMrIscf65MORhMJc0vENG4KWBQczbAL9oGMHLqhZNtnFtLdnMW+KUaNTIoIMmBnRH1INU/wGG0Kg==
+  dependencies:
+    "@boomerang-io/carbon-addons-boomerang-react" "1.1.7"
+    "@carbon/icons-react" "10.22.0"
+    "@gatsby-contrib/gatsby-plugin-elasticlunr-search" "3.0.2"
+    app-root-path "2.2.1"
+    axios "0.21.1"
+    carbon-components "10.25.0"
+    carbon-components-react "7.25.0"
+    carbon-icons "7.0.7"
+    classnames "2.2.6"
+    core-js "2.6.11"
+    dotenv "8.2.0"
+    downshift "^6.0.6"
+    elasticlunr "0.9.5"
+    formik "2.2.5"
+    gatsby-alias-imports "1.0.6"
+    gatsby-plugin-catch-links "3.6.0"
+    gatsby-plugin-layout "2.6.0"
+    gatsby-plugin-manifest "3.6.0"
+    gatsby-plugin-meta-redirect "1.1.1"
+    gatsby-plugin-react-helmet "4.1.0"
+    gatsby-plugin-sass "4.6.0"
+    gatsby-plugin-sharp "3.6.0"
+    gatsby-plugin-sitemap "4.2.0"
+    gatsby-remark-autolink-headers "4.3.0"
+    gatsby-remark-copy-linked-files "4.3.0"
+    gatsby-remark-external-links "0.0.4"
+    gatsby-remark-images "5.3.0"
+    gatsby-remark-prismjs "5.3.0"
+    gatsby-source-filesystem "3.6.0"
+    gatsby-transformer-remark "4.3.0"
+    is-absolute-url "3.0.3"
+    lodash.capitalize "4.2.1"
+    lodash.flatten "4.4.0"
+    lodash.kebabcase "4.1.1"
+    lodash.sortby "4.7.0"
+    lodash.startcase "4.4.0"
+    miragejs "0.1.41"
+    moment "2.29.1"
+    node-html-parser "^1.1.15"
+    node-sass "^4.14.0"
+    postcss "7.0.35"
+    prismjs "1.23.0"
+    prop-types "15.7.2"
+    react-helmet "6.1.0"
+    react-query "2.26.2"
+    react-router-dom "5.1.2"
+    semver "7.3.2"
+    smooth-scroll "16.1.3"
+    typeface-ibm-plex-sans "0.0.75"
+    window-or-global "1.0.1"
+    yup "0.29.3"
+
 "@carbon/colors@^10.22.0":
   version "10.22.0"
   resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.22.0.tgz#a8cb6c9ee23ab6f49173bb7e71acfe41a1ee9d9d"
@@ -13508,6 +13591,15 @@ postcss@7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+postcss@7.0.35, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
+  version "7.0.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
+  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@8.2.6:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.6.tgz#5d69a974543b45f87e464bc4c3e392a97d6be9fe"
@@ -13525,15 +13617,6 @@ postcss@8.3.0, postcss@^8.2.9:
     colorette "^1.2.2"
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
-
-postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 postcss@^8.2.8:
   version "8.2.8"


### PR DESCRIPTION
Closes #

[ISEEC-2421](https://tools.boomerangplatform.net/jira/console/browse/ISEEC-2421) - The requests icon is missing from UIShell on Docs

#### Changelog
update carbon-addons-boomerang-react to 1.2.3

#### Testing / Reviewing

When on Docs route, check if header contain the requests icon 
