### PR TITLE
feat [ISEEC-3259] Update to Gatsby Theme to check for User Role

### DIFF
--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "0.2.2-beta.2",
+  "version": "0.2.2-beta.3",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.2",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/packages/gatsby-theme-boomerang/src/components/App/index.js
+++ b/packages/gatsby-theme-boomerang/src/components/App/index.js
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { AppContext } from "@gatsby-theme-boomerang/state";
-import { useSideNavScrollManager } from "@gatsby-theme-boomerang/hooks";
 import { useQuery } from "react-query";
-import { Loading } from "@boomerang-io/carbon-addons-boomerang-react";
+import { Error403, Loading } from "@boomerang-io/carbon-addons-boomerang-react";
 import ErrorFullPage from "@gatsby-theme-boomerang/components/ErrorFullPage";
 import Header from "@gatsby-theme-boomerang/components/Header";
-import { useTracking } from "@gatsby-theme-boomerang/hooks";
+import { useSideNavScrollManager, useTracking } from "@gatsby-theme-boomerang/hooks";
+import { UserPlatformRole } from "@gatsby-theme-boomerang/constants";
 import { resolver, serviceUrl } from "@gatsby-theme-boomerang/config/servicesConfig";
 
 const GET_USER_URL = serviceUrl.getUserProfile();
@@ -60,10 +60,18 @@ export default function App({ children, location, isGaActive }) {
   }
 
   if (userQuery.data && navigationQuery.data) {
+    const renderContent = () => {
+      if (userQuery.data.type === UserPlatformRole.Partner) {
+        return <Error403 />;
+      }
+
+      return children;
+    };
+
     return (
       <AppContext.Provider value={{ isSideNavMounted, setIsSideNavMounted }}>
         <Header navigation={navigationQuery.data} user={userQuery.data} />
-        {children}
+        {renderContent()}
       </AppContext.Provider>
     );
   }

--- a/packages/gatsby-theme-boomerang/src/constants/index.js
+++ b/packages/gatsby-theme-boomerang/src/constants/index.js
@@ -23,3 +23,7 @@ export const contentLabelsToImageMap = {
   [ContentLabels.ProcessDeliveryAccelerator]: ProcessDeliveryAccelerator,
   [ContentLabels.Watson]: Watson,
 };
+
+export const UserPlatformRole = {
+  Partner: "partner",
+};


### PR DESCRIPTION
Closes #

ISEEC-3259: We want to check the user type before we show any of our docs. If the user type is `partner` -> then we want to display our 403 error page.

#### Changelog

**Changed**

- Updated App component to check user role.

#### Testing / Reviewing

If testing locally, change gatsby-config to have "standaloneMode: false" and write "localhost:8000/docs" directly in the url.

#### Additional Info
Related PR: https://github.ibm.com/essentials-core/core.app.docs/pull/261