### PR TITLE
chore: upgrade internal packages

### DIFF
--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "1.3.0",
+  "version": "1.3.1-beta.0",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",
   "dependencies": {
-    "@boomerang-io/carbon-addons-boomerang-react": "3.0.0",
+    "@boomerang-io/carbon-addons-boomerang-react": "3.1.0",
     "@boomerang-io/styles": "^1.1.0",
     "@carbon/react": "1.13.0",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "3.0.2",


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

just bumping the carbon addons so that we can have appSwitcher in essentials docs