### PR TITLE
fix:ICA1-432:update scroll padding to prevent clipping of headings

### DIFF
--- a/packages/gatsby-theme-boomerang/package.json
+++ b/packages/gatsby-theme-boomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boomerang-io/gatsby-theme-boomerang",
-  "version": "1.7.16",
+  "version": "1.7.17-beta.1",
   "main": "index.js",
   "author": "Timothy Bula <timrbula@gmail.com> (@timrbula)",
   "license": "MIT",

--- a/packages/gatsby-theme-boomerang/src/styles/index.scss
+++ b/packages/gatsby-theme-boomerang/src/styles/index.scss
@@ -5,6 +5,7 @@
 html,
 body {
   font-family: "IBM Plex Sans", "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
+  scroll-padding-top: 3rem;
 }
 
 body {


### PR DESCRIPTION
Closes # ICA1-432

update scroll padding to prevent clipping of headings

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
